### PR TITLE
feat: use csv_path in properties

### DIFF
--- a/src/main/java/com/brasil/transparente/processor/service/ExecutivoGeneratorService.java
+++ b/src/main/java/com/brasil/transparente/processor/service/ExecutivoGeneratorService.java
@@ -7,10 +7,12 @@ import com.brasil.transparente.processor.util.EmbaixadasConstants;
 import com.brasil.transparente.processor.util.NameCorrector;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -23,6 +25,9 @@ public class ExecutivoGeneratorService {
     private GeneralGeneratorService generalGeneratorService;
     @Autowired
     private NameCorrector nameCorrector;
+
+    @Value("${CSV_PATH}")
+    private String csvPath;
 
     private static final String EXECUTIVO = "Poder Executivo";
     private static final String PRECATORIOS_RPVS = "Precatórios e Requisições de Pequeno Valor";
@@ -47,7 +52,8 @@ public class ExecutivoGeneratorService {
             String yearString = String.valueOf(year);
             String monthString = String.format("%02d", month);
             String documentNumber = yearString + monthString;
-            String filePath = "PATH\\brasil-transparente-resources\\Executivo\\despesas" + year + "\\" + documentNumber + ".csv";
+            String relativePath = "/Executivo/despesas" + year + "/" + documentNumber + ".csv";
+            String filePath = Paths.get(csvPath, relativePath).toString();
             String delimiter = ";";
             createExpensesStructure(filePath, delimiter, year, month);
             month++;
@@ -119,7 +125,8 @@ public class ExecutivoGeneratorService {
     }
 
     private void peekOnStfAndComplementStructure() {
-        String filePath = "PATH\\brasil-transparente-resources\\Judiciario\\Supremo Tribunal Federal\\STF.csv";
+        String relativePath = "/Judiciario/Supremo Tribunal Federal/STF.csv";
+        String filePath = Paths.get(csvPath, relativePath).toString();
         String delimiter = ",";
         log.info("STF - Lendo arquivos de despesas e criando estrutura de despesa.");
         try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8))) {
@@ -165,7 +172,8 @@ public class ExecutivoGeneratorService {
             String yearString = String.valueOf(year);
             String monthString = String.format("%02d", month);
             String documentNumber = yearString + monthString;
-            String filePath = "PATH\\brasil-transparente-resources\\Judiciario\\Justiça Federal\\" + documentNumber + ".csv";
+            String relativePath = "\\Judiciario\\Justiça Federal\\";
+            String filePath = csvPath + relativePath + documentNumber + ".csv";
             String delimiter = "\t";
             log.info("Justiça Federal - Lendo arquivos de despesas e criando estrutura de despesa. Mês = {}", month);
             try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filePath), StandardCharsets.UTF_8))) {
@@ -237,7 +245,7 @@ public class ExecutivoGeneratorService {
         } else if (unidadeGestora.contains("- MOEDA LOCAL")) {
             return switch (unidadeGestora) {
                 case EmbaixadasConstants.EMBAIXADA_CHINA_PEQUIM_LOCAL, EmbaixadasConstants.EMBAIXADA_CHINA_CANTAO_LOCAL,
-                     EmbaixadasConstants.EMBAIXADA_CHINA_XANGAI_LOCAL -> valorPago * Currency2024Constants.YUAN;
+                        EmbaixadasConstants.EMBAIXADA_CHINA_XANGAI_LOCAL -> valorPago * Currency2024Constants.YUAN;
                 case EmbaixadasConstants.EMBAIXADA_BOLIVIA_LOCAL -> valorPago * Currency2024Constants.BOLIVIANO;
                 case EmbaixadasConstants.EMBAIXADA_TAILANDIA_LOCAL -> valorPago * Currency2024Constants.BAHT;
                 case EmbaixadasConstants.EMBAIXADA_POLONIA_LOCAL -> valorPago * Currency2024Constants.ZLOTY;

--- a/src/main/java/com/brasil/transparente/processor/service/JudiciarioGeneratorService.java
+++ b/src/main/java/com/brasil/transparente/processor/service/JudiciarioGeneratorService.java
@@ -4,12 +4,14 @@ import com.brasil.transparente.processor.entity.*;
 import com.brasil.transparente.processor.util.Constants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -20,6 +22,9 @@ public class JudiciarioGeneratorService {
 
     @Autowired
     private GeneralGeneratorService generalGeneratorService;
+
+    @Value("${CSV_PATH}")
+    private String csvPath;
 
     private static final String JUDICIARIO = "Poder Judiciário";
     Poder poder = new Poder(JUDICIARIO);
@@ -51,7 +56,8 @@ public class JudiciarioGeneratorService {
     }
 
     private void generateSuperiorTribunalFederal() {
-        String filePath = "PATH\\brasil-transparente-resources\\Judiciario\\Supremo Tribunal Federal\\STF.csv";
+        String relativePath = "/Judiciario/Supremo Tribunal Federal/STF.csv";
+        String filePath = Paths.get(csvPath, relativePath).toString();
         String delimiter = ",";
         createExpenseStructureStf(filePath, delimiter);
     }
@@ -62,7 +68,8 @@ public class JudiciarioGeneratorService {
             String yearString = String.valueOf(year);
             String monthString = String.format("%02d", month);
             String documentNumber = yearString + monthString;
-            String filePath = "PATH\\brasil-transparente-resources\\Judiciario\\" + tribunal + "\\" + documentNumber + ".csv";
+            String relativePath = "/Judiciario/" + tribunal + "/" + documentNumber + ".csv";
+            String filePath = Paths.get(csvPath, relativePath).toString();
             String delimiter = "\t";
             createStandardJusticeExpenseStrucutre(filePath, delimiter, month, tribunal);
             month++;

--- a/src/main/java/com/brasil/transparente/processor/service/LegislativoGeneratorService.java
+++ b/src/main/java/com/brasil/transparente/processor/service/LegislativoGeneratorService.java
@@ -4,6 +4,7 @@ import com.brasil.transparente.processor.entity.*;
 import com.brasil.transparente.processor.util.Constants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -11,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -21,6 +23,9 @@ public class LegislativoGeneratorService {
 
     @Autowired
     private GeneralGeneratorService generalGeneratorService;
+
+    @Value("${CSV_PATH}")
+    private String csvPath;
 
     private static final String LEGISLATIVO = "Poder Legislativo";
     Poder poder = new Poder(LEGISLATIVO);
@@ -38,13 +43,15 @@ public class LegislativoGeneratorService {
     }
 
     private void generateCamaraDeputados() {
-        String filePath = "PATH\\brasil-transparente-resources\\Legislativo\\CamaraDeputados.csv";
+        String relativePath = "Legislativo/CamaraDeputados.csv";
+        String filePath = Paths.get(csvPath, relativePath).toString();
         String delimiter = "\t";
         createCamaraDeputadosStructure(filePath, delimiter);
     }
 
     private void generateSenado() {
-        String filePath = "PATH\\brasil-transparente-resources\\Legislativo\\Senado.csv";
+        String relativePath = "Legislativo/Senado.csv";
+        String filePath = Paths.get(csvPath, relativePath).toString();
         String delimiter = "\t";
         createSenadoFederalStructure(filePath, delimiter);
     }

--- a/src/main/java/com/brasil/transparente/processor/service/OrgaosAutonomosGeneratorService.java
+++ b/src/main/java/com/brasil/transparente/processor/service/OrgaosAutonomosGeneratorService.java
@@ -4,6 +4,7 @@ import com.brasil.transparente.processor.entity.*;
 import com.brasil.transparente.processor.util.Constants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -11,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -21,6 +23,9 @@ public class OrgaosAutonomosGeneratorService {
 
     @Autowired
     private GeneralGeneratorService generalGeneratorService;
+
+    @Value("${CSV_PATH}")
+    private String csvPath;
 
     private static final String ORGAOS_AUTONOMOS = "Órgãos Autônomos";
     Poder poder = new Poder(ORGAOS_AUTONOMOS);
@@ -51,10 +56,11 @@ public class OrgaosAutonomosGeneratorService {
     private void generateTribunalContasUniao(String year) {
         int month = 1;
         while (month <= 12) {
-            String yearString = String.valueOf(year);
             String monthString = String.format("%02d", month);
-            String documentNumber = yearString + monthString;
-            String filePath = "PATH\\brasil-transparente-resources\\Orgaos Autonomos\\Tribunal de Contas da Uniao\\" + documentNumber + ".csv";
+            String documentNumber = year + monthString;
+            String relativePath = "/Orgaos Autonomos/Tribunal de Contas da Uniao/";
+            String fileName = documentNumber + ".csv";
+            String filePath = Paths.get(csvPath, relativePath, fileName).toString();
             String delimiter = ";";
             createTribunalContasUniaoStructure(filePath, delimiter, month);
             month++;
@@ -62,13 +68,15 @@ public class OrgaosAutonomosGeneratorService {
     }
 
     private void generateDefensoriaPublicaUniao() {
-        String filePath = "PATH\\brasil-transparente-resources\\Orgaos Autonomos\\Defensoria Publica da Uniao\\2024.csv";
+        String relativePath = "/Orgaos Autonomos/Defensoria Publica da Uniao/2024.csv";
+        String filePath = Paths.get(csvPath, relativePath).toString();
         String delimiter = ";";
         createDefensoriaPublicaUniaoStructure(filePath, delimiter);
     }
 
     private void generateMinisterioPublico(String nameOrgao) {
-        String filePath = "PATH\\brasil-transparente-resources\\Orgaos Autonomos\\Ministerio Publico\\" + nameOrgao + "\\2024.csv";
+        String relativePath = "/Orgaos Autonomos/Ministerio Publico/" + nameOrgao + "/2024.csv";
+        String filePath = Paths.get(csvPath, relativePath).toString();
         String delimiter = ";";
         createMinisterioPublicoUniaoStructure(filePath, delimiter, nameOrgao);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.datasource.url=jdbc:mariadb://localhost:3306/gastos
 spring.datasource.username=${DB_USER_LOCAL}
 spring.datasource.password=${DB_PASSWORD_LOCAL}
+CSV_PATH=${CSV_PATH_LOCAL}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Primeiro passo para "deschumbar" o path dos arquivos da maquina local, permitindo alterar dinamicamente via properties.
O `Path.gets()` abstrai a questão das barras duplas, não sendo necessário utiliza-las